### PR TITLE
Containerized the app using Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Ignore environment files
+.env
+
+# Logs
+*.log
+logs/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Node modules
+node_modules/
+
+# Build output
+dist/
+build/
+
+# Dependency directories
+.pnp/
+.pnp.js
+
+# IDE/editor settings
+.vscode/
+.idea/
+*.iml
+
+# System files
+.DS_Store
+Thumbs.db
+
+# Docker
+*.pid
+docker-compose.override.yml
+
+# Java/Maven
+target/
+*.class
+*.jar
+*.war
+*.ear
+
+# OS-specific
+*.swp
+*~

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+services:
+  backend:
+    build:
+      context: ./taxi-service # Points to your Spring Boot app folder
+      dockerfile: Dockerfile # The backend Dockerfile in taxi-service folder
+    image: taxi-service-backend
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/${MYSQL_DATABASE}
+      - SPRING_DATASOURCE_USERNAME=${MYSQL_USER}
+      - SPRING_DATASOURCE_PASSWORD=${MYSQL_PASSWORD}
+    depends_on: # Modified to wait for db to be healthy
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./taxi-service-frontend
+      dockerfile: Dockerfile
+    image: taxi-service-frontend
+    ports:
+      - "5176:80" # Maps container port 80 (Nginx) to host port 5176
+    depends_on: # frontend might depend on backend being available
+      - backend
+    restart: unless-stopped
+
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    ports:
+      - "3307:3306"
+    volumes:
+      - taxi_db_data:/var/lib/mysql
+    healthcheck: # healthcheck for the database
+      test:
+        [
+          "CMD",
+          "mysqladmin",
+          "ping",
+          "-h",
+          "localhost",
+          "-u${MYSQL_USER}",
+          "-p${MYSQL_PASSWORD}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s # Gives MySQL time to initialize before checks begin
+    restart: unless-stopped
+
+volumes:
+  taxi_db_data:

--- a/taxi-service-frontend/.dockerignore
+++ b/taxi-service-frontend/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+node_modules/
+dist/
+.env
+.env*.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+coverage/

--- a/taxi-service-frontend/Dockerfile
+++ b/taxi-service-frontend/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1
+FROM node:18 AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+# Stage 2
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/taxi-service/.dockerignore
+++ b/taxi-service/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+target/
+*.log
+.idea/

--- a/taxi-service/Dockerfile
+++ b/taxi-service/Dockerfile
@@ -1,0 +1,18 @@
+# Stage 1
+FROM maven:3.9.8-eclipse-temurin-17 AS build
+WORKDIR /app
+
+COPY pom.xml .
+COPY src ./src
+
+RUN mvn clean package -DskipTests
+
+# Stage 2
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+
+COPY --from=build /app/target/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/taxi-service/src/main/java/com/taxi/taxi_service/config/WebConfig.java
+++ b/taxi-service/src/main/java/com/taxi/taxi_service/config/WebConfig.java
@@ -6,9 +6,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/api/**")
-				.allowedOrigins("http://localhost:3000", "http://localhost:5173")
+				.allowedOrigins(
+					"http://localhost:3000",  // For other local dev instances if needed
+					"http://localhost:5173",  // For Vite dev server (npm run dev)
+					"http://localhost:5176"   // For your Dockerized frontend
+				)
 				.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 				.allowedHeaders("*")
 				.allowCredentials(true);

--- a/taxi-service/src/main/resources/application.properties
+++ b/taxi-service/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 spring.application.name=TaxiService
 
-# MySQL Connection
-spring.datasource.url=jdbc:mysql://localhost:3306/taxiservice_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-spring.datasource.username=root
-spring.datasource.password=root
+# MySQL connection (use Docker service name 'db' instead of 'localhost')
+spring.datasource.url=jdbc:mysql://db:3306/${MYSQL_DATABASE}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+spring.datasource.username=${MYSQL_USER}
+spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# JPA/Hibernate
-spring.jpa.hibernate.ddl.auto=validate 
+# JPA / Hibernate
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
# Taxi Service App

## Description

This project consists of a Spring Boot backend and a React frontend application designed to load, serve, and display Taxi trip data along with taxi zone information. It provides RESTful API endpoints to query trip summaries, top zones, and detailed trip data with support for filtering, sorting, and pagination.

## Technologies Used

**Backend:**

* Java 17+
* Spring Boot 3.x
* Spring Data JPA (Hibernate)
* Spring Web
* MySQL (Database)
* Lombok
* OpenCSV (for data loading)
* Maven

**Frontend:**

* React.js
* Axios (for API calls)
* CSS Modules (for styling)
* Node.js / npm (or yarn) for development environment

**Deployment:**

* Docker
* Docker Compose

## Core Features

* **Data Loading:** Loads initial zone and trip data from CSV files into the MySQL database on backend startup (`DataLoaderService`).
* **Backend API (`/api` base path):**
    * `GET /zones`: Retrieves a list of all taxi zones.
    * `GET /top-zones`: Retrieves the top 5 zones based on pickup or dropoff counts (`?orderBy=pickups` or `?orderBy=dropoffs`).
    * `GET /zone-trips`: Retrieves a daily summary (pickup/dropoff counts) for a specific zone (`?zoneId=...&date=YYYY-MM-DD`).
    * `GET /list-trips`: Retrieves a paginated, filterable, and sortable list of taxi trips. Supports filtering by pickup/dropoff zone IDs and dates, sorting by pickup/dropoff times, and standard pagination (`?page=`, `?size=`, `?sort=...`).
* **Frontend UI:**
    * Displays Top 5 zones dynamically based on selected criteria (pickups/dropoffs).
    * Provides a form to select a zone and date to view the daily trip summary.
    * Presents a table view of detailed trip records with controls for filtering (by zone/date), sorting (by time), and pagination (next/previous page, items per page).

## Setup & Running

### Option 1: Run with Docker (Recommended)

**Prerequisites:**

* Docker
* Docker Compose

**Steps:**

1.  Place your data files `taxi_zone_lookup.csv` and `yellow_tripdata.csv` inside the backend's `src/main/resources/data/` directory.
2.  Create a `.env` file in the project root (same level as `docker-compose.yml`) with the following content:

    ```env
    MYSQL_ROOT_PASSWORD=your_root_password
    MYSQL_DATABASE=taxiservice_db
    MYSQL_USER=your_db_user
    MYSQL_PASSWORD=your_db_password
    ```

3.  Build and start the containers:

    ```bash
    docker-compose up --build
    ```

4.  Access the frontend at `http://localhost:3000` and backend API at `http://localhost:8080/api`.

### Option 2: Manual Setup (Without Docker)

**Prerequisites:**

* Java JDK (17 or later)
* Apache Maven
* MySQL Server
* Node.js and npm (or yarn)

**Backend:**

1.  **Database Setup:**
    * Ensure MySQL server is running.
    * Create the database: `CREATE DATABASE IF NOT EXISTS taxiservice_db;`
    * Manually create the `zone` and `trip` tables within `taxiservice_db` using appropriate SQL `CREATE TABLE` statements matching the `Zone` and `Trip` entities.
2.  **Configuration:** Update database URL, username, and password in `src/main/resources/application.properties` if they differ from the defaults provided. Ensure `spring.jpa.hibernate.ddl-auto` is set appropriately (e.g., `validate` or `none` after tables are created).
3.  **Data Files:** Place `taxi_zone_lookup.csv` and `yellow_tripdata.csv` (or your actual trip data file name) inside the `src/main/resources/data/` directory.
4.  **Run:** Navigate to the backend directory in a terminal and run: `mvn spring-boot:run` (or run the `TaxiServiceApplication` main method from your IDE). The backend should start, typically on port 8080.

**Frontend:**

1.  **Navigate:** Open a terminal in the frontend project's root directory.
2.  **Install Dependencies:** Run `npm install` (or `yarn install`).
3.  **Configuration:** Verify the `baseURL` in `src/services/api.js` points to your running backend (e.g., `http://localhost:8080/api`).
4.  **Run:** Start the development server: `npm start` (or `yarn start`).
5.  **Access:** Open your browser to the address provided (usually `http://localhost:5173` for Vite or `http://localhost:3000` for CRA).

## Frontend UI

![image](https://github.com/user-attachments/assets/061feba6-27cd-4174-b797-26ada68ba041)

![image](https://github.com/user-attachments/assets/637526ab-e26c-4664-b92c-9b5b3c2e1bd0)
